### PR TITLE
Update dependencies to compile more easily

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 name = "autopy"
 
 [dependencies.autopilot]
-path = "../autopilot-rs"
+version = "0.4.0"
 
 [dependencies.pyo3]
 version = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 name = "autopy"
 
 [dependencies.autopilot]
-version = "0.4.0"
+path = "../autopilot-rs"
 
 [dependencies.pyo3]
-version = "0.6.0"
+version = "0.8.1"
 default-features = false
 
 [dependencies.image]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build: ## Build debug target for development.
-	rustup default nightly-2019-10-05
+	rustup default nightly
 	pip install -r requirements.txt
 	python setup.py build
 
@@ -14,7 +14,7 @@ help: ## Print help information.
 
 .PHONY: install
 install: ## Install local target.
-	pip install .
+	pip3install .
 
 .PHONY: mac
 mac: ## Build wheel distributions for macOS.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 # From https://github.com/starkat99/appveyor-rust/blob/master/appveyor.yml
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init -yv --default-toolchain nightly-2019-10-05 --default-host %target%
+  - rustup-init -yv --default-toolchain nightly --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![feature(specialization, const_fn, custom_attribute)]
+#![feature(specialization, const_fn)]
 
 extern crate autopilot;
 extern crate either;


### PR DESCRIPTION
Using an Ubuntu 19.10 machine, I couldn't compile the project (issue with doctests that threw an error message at compilation when I was on the nightly branch specified in the README.md). So I replaced the pyo3 dependency with the latest version (v. 0.8.1) compatible with the autopy project. Thanks to this modification, I can compile directly from nightly without any problem and autopy works well.