### PR TITLE
Makefile pipinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Print help information.
 
 .PHONY: install
 install: ## Install local target.
-	pip3install .
+	pip install .
 
 .PHONY: mac
 mac: ## Build wheel distributions for macOS.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![feature(specialization, const_fn)]
+// #![feature(specialization, const_fn)]
 
 extern crate autopilot;
 extern crate either;


### PR DESCRIPTION
 makefile pip install with default python version and separated from pip3install to solve cmd invalid error