### PR TITLE
add video element to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ def sine_mouse_wave():
 sine_mouse_wave()
 ```
 
-<a href="https://www.autopy.org/documentation/sine-wave"><img src="https://github.com/autopilot-rs/autopy/raw/gh-pages/sine-move-mouse-thumbnail.jpg" alt="Demonstration video"/></a>
+<video controls src="https://github.com/autopilot-rs/autopy/assets/9993663/379ee2a6-5d3e-4f1e-a0bd-420660351875" width="640" alt="Demonstration video"></video>
 
 ### Controlling the Keyboard
 


### PR DESCRIPTION
The readme currently links to a page on the autopy website, the page embeds a Flash video player, which modern browser can not play.

![chrome_FY0Gv7qyJu](https://github.com/autopilot-rs/autopy/assets/9993663/573c8b13-3b77-4d65-8c60-24abaca397dc)


I downloaded the video and uploaded it to GitHub through the issue markdown editor and copied the link that the issue editor created to use for the video element. 
The video was in a mov container and I converted to a mp4 container using ffmpeg, with `-crf 15` so the video is not compressed again, so it retains its image quality.

```bash
ffmpeg -i sine-move-mouse\ \[sine-move-mouse\].mov -crf 15 sine-move-mouse\ \[sine-move-mouse\].mp4
 ```

The video is only 136KB by the way, insignificantly small.

result:
![chrome_WtaT8lprWx](https://github.com/autopilot-rs/autopy/assets/9993663/09dc82dd-a670-426f-898e-c1762ac6225f)
